### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules/
 .env


### PR DESCRIPTION
Uma dica, server para todos e qualquer projeto: normalmente a pasta `node_modules` é muito pesada, dito isso nós não subimos ela junto com o projeto no Github intende? Quando a gente instala uma dependência seja ela de desenvolvimento ou não ela fica gravada no seu `package.json`, então na hora que você for versionar o projeto com o Git para poder subir para o Github você pode excluir a pasta  `node_modules`.  Ai depois quando você for trabalhar no projeto novamente você não precisa instalar dependência por dependência, bastas apenas entrar na pasta do projeto e mandar um `npm install` que ele vai lá no seu `package.json`, olha quais dependências estão instaladas e baixa elas. Existe um forma de você gerar arquivos `.gitignore` bem completos de uma forma bem simples, use o comando: `npx gitignore node`